### PR TITLE
eap_peer: Make the QMI EAP proxy a standalone lib

### DIFF
--- a/src/eap_peer/eap_proxy_qmi.c
+++ b/src/eap_peer/eap_proxy_qmi.c
@@ -1444,6 +1444,7 @@ static char bin_to_hexchar(u8 ch)
 	return ch + 'a' - 10;
 }
 
+extern struct eap_peer_config * eap_get_config(struct eap_sm *sm) __attribute__((weak));
 static Boolean eap_proxy_build_identity(struct eap_proxy_sm *eap_proxy, u8 id, struct eap_sm *eap_sm)
 {
 	struct eap_hdr *resp;

--- a/wpa_supplicant/Android.mk
+++ b/wpa_supplicant/Android.mk
@@ -509,7 +509,11 @@ endif
 
 ifdef CONFIG_EAP_PROXY
 L_CFLAGS += -DCONFIG_EAP_PROXY
+ifneq ($(CONFIG_EAP_PROXY),qmi)
+# QMI needs proprietary headers to build :(
+# Spin it into a blobbable lib
 OBJS += src/eap_peer/eap_proxy_$(CONFIG_EAP_PROXY).c
+endif
 include $(LOCAL_PATH)/eap_proxy_$(CONFIG_EAP_PROXY).mk
 CONFIG_IEEE8021X_EAPOL=y
 endif
@@ -1554,6 +1558,30 @@ LOCAL_SRC_FILES := $(OBJS_c)
 LOCAL_C_INCLUDES := $(INCLUDES)
 include $(BUILD_EXECUTABLE)
 
+# This needs QMI artifacts to be built
+ifneq ($(QCPATH),)
+
+ifeq ($(CONFIG_EAP_PROXY),qmi)
+include $(CLEAR_VARS)
+
+LOCAL_MODULE = libwpa_qmi_eap_proxy
+LOCAL_SHARED_LIBRARIES := libcutils liblog libwpa_client
+LOCAL_SRC_FILES += src/eap_peer/eap_proxy_$(CONFIG_EAP_PROXY).c
+LOCAL_SRC_FILES += src/utils/wpa_debug.c
+LOCAL_SRC_FILES += src/utils/wpabuf.c
+include $(LOCAL_PATH)/eap_proxy_$(CONFIG_EAP_PROXY).mk
+LOCAL_C_INCLUDES := $(INCLUDES)
+LOCAL_CFLAGS = $(L_CFLAGS)
+
+LOCAL_STATIC_LIBRARIES += $(LIB_STATIC_EAP_PROXY)
+LOCAL_SHARED_LIBRARIES += $(LIB_SHARED_EAP_PROXY)
+
+include $(BUILD_SHARED_LIBRARY)
+
+endif # qmi EAP_PROXY
+endif # QCPATH
+
+
 ########################
 include $(CLEAR_VARS)
 LOCAL_MODULE := wpa_supplicant
@@ -1565,8 +1593,13 @@ LOCAL_STATIC_LIBRARIES += $(BOARD_WPA_SUPPLICANT_PRIVATE_LIB)
 endif
 LOCAL_SHARED_LIBRARIES := libc libcutils liblog
 ifdef CONFIG_EAP_PROXY
+ifneq ($(CONFIG_EAP_PROXY),qmi)
 LOCAL_STATIC_LIBRARIES += $(LIB_STATIC_EAP_PROXY)
 LOCAL_SHARED_LIBRARIES += $(LIB_SHARED_EAP_PROXY)
+else
+LOCAL_SHARED_LIBRARIES += libwpa_qmi_eap_proxy
+LOCAL_ADDITIONAL_DEPENDENCIES += $(LIB_SHARED_EAP_PROXY)
+endif
 endif
 ifeq ($(CONFIG_TLS), openssl)
 LOCAL_SHARED_LIBRARIES += libcrypto libssl libkeystore_binder


### PR DESCRIPTION
This code can't be built without linking to some proprietary libs
and headers. Split it off so a prebuilt can be distributed for
OSS builds

Ref: CYNGNOS-428

Change-Id: I430dda72e8cb156d86ef286244230bb3f511ca23
